### PR TITLE
fix(write options): add missing cache-control header

### DIFF
--- a/src/Drivers/S3.ts
+++ b/src/Drivers/S3.ts
@@ -86,6 +86,7 @@ export class S3Driver implements S3DriverContract {
       contentDisposition,
       contentEncoding,
       contentLanguage,
+      cacheControl,
       ...adapterOptions
     } = Object.assign({ visibility: this.config.visibility }, options)
 
@@ -103,6 +104,10 @@ export class S3Driver implements S3DriverContract {
 
     if (contentLanguage) {
       adapterOptions['ContentLanguage'] = contentLanguage
+    }
+
+    if (cacheControl) {
+      adapterOptions['CacheControl'] = cacheControl
     }
 
     if (visibility === 'public') {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Add the CacheControl header during the writing options phase. Without this, the header used during the upload is 'controlCache', and it's not taken into account by S3 as metadata.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/null/blob/master/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
